### PR TITLE
Add Automated IRIDA Uploads

### DIFF
--- a/.github/ci-data/test_metadata.csv
+++ b/.github/ci-data/test_metadata.csv
@@ -1,0 +1,4 @@
+sample,val1,val2,val3,val4
+Sample1,231,ABCDE,:),NA
+blank1,543,XYZ,4,NULL
+extra_sample_not_avail,2,A,4,A

--- a/.github/scripts/run_mpx_pipeline.sh
+++ b/.github/scripts/run_mpx_pipeline.sh
@@ -16,13 +16,17 @@ nextflow run ./main.nf \
 
 # Check that the output is as expected
 # 1. Num Reads
-if [[ `awk -F, '$1 == "Sample1" {print $2}' ./results/overall_sample_quality.csv` != 26280 ]]; then 
+READS=`awk -F, '$1 == "Sample1" {print $2}' ./results/overall_sample_quality.csv`
+if [[ "$READS" != "26280" ]]; then 
     echo "Incorrect output: Number of reads mapped"
+    echo "  Expected: 26280, Got: $READS"
     exit 1
 fi
 # 2. Genome Completeness
-if [[ `awk -F, '$1 == "Sample1" {print $6}' ./results/overall_sample_quality.csv` != 0.845519 ]]; then 
+COMPLETENESS=`awk -F, '$1 == "Sample1" {print $6}' ./results/overall_sample_quality.csv | xargs printf "%.2f"`
+if [[ "$COMPLETENESS" != "0.85" ]]; then 
     echo "Incorrect output: Genome Completeness"
+    echo "  Expected: 0.85, Got: $COMPLETENESS"
     exit 1
 fi
 

--- a/.github/scripts/run_mpx_pipeline.sh
+++ b/.github/scripts/run_mpx_pipeline.sh
@@ -16,12 +16,12 @@ nextflow run ./main.nf \
 
 # Check that the output is as expected
 # 1. Num Reads
-if [[ `awk -F, '$1 == "Sample1" {print $2}' overall_sample_quality.csv` != 26280 ]]; then 
+if [[ `awk -F, '$1 == "Sample1" {print $2}' ./results/overall_sample_quality.csv` != 26280 ]]; then 
     echo "Incorrect output: Number of reads mapped"
     exit 1
 fi
 # 2. Genome Completeness
-if [[ `awk -F, '$1 == "Sample1" {print $6}' overall_sample_quality.csv` != 0.845519 ]]; then 
+if [[ `awk -F, '$1 == "Sample1" {print $6}' ./results/overall_sample_quality.csv` != 0.845519 ]]; then 
     echo "Incorrect output: Genome Completeness"
     exit 1
 fi

--- a/.github/scripts/run_mpx_pipeline_metadata.sh
+++ b/.github/scripts/run_mpx_pipeline_metadata.sh
@@ -1,11 +1,7 @@
 #!/bin/bash
 set -eo pipefail
 
-# Create a Cache Dir
-mkdir -p conda_cache_dir
-
-# Get partial human ref genome
-gunzip $PWD/.github/ci-data/partial_hg38_ref.fa.gz
+# Test is run second so no need to re-create envs or unzip files
 
 # Run Illumina Pipeline
 nextflow run ./main.nf \
@@ -13,6 +9,7 @@ nextflow run ./main.nf \
     --cache ./conda_cache_dir \
     --directory $PWD/.github/ci-data/ \
     --human_ref $PWD/.github/ci-data/partial_hg38_ref.fa
+    --metadata_csv $PWD/.github/ci-data/test_metadata.csv
 
 # Check that the output is as expected
 # 1. Num Reads
@@ -25,9 +22,14 @@ if [[ `awk -F, '$1 == "Sample1" {print $6}' overall_sample_quality.csv` != 0.845
     echo "Incorrect output: Genome Completeness"
     exit 1
 fi
+# 3. Check metadata put in correctly
+if [[ `awk -F, '$1 == "Sample1" {print $7}' overall_sample_quality.csv` != 231 ]]; then 
+    echo "Incorrect output: Metadata not parsed correctly"
+    exit 1
+fi
 
 # Reset and Track
-mv .nextflow.log artifacts/nextflow.log
+mv .nextflow.log artifacts/nextflow2.log
 rm -rf results work/ .nextflow*
 
 echo "Passed Tests"

--- a/.github/scripts/run_mpx_pipeline_metadata.sh
+++ b/.github/scripts/run_mpx_pipeline_metadata.sh
@@ -13,18 +13,24 @@ nextflow run ./main.nf \
 
 # Check that the output is as expected
 # 1. Num Reads
-if [[ `awk -F, '$1 == "Sample1" {print $2}' ./results/overall_sample_quality.csv` != 26280 ]]; then 
+READS=`awk -F, '$1 == "Sample1" {print $2}' ./results/overall_sample_quality.csv`
+if [[ "$READS" != "26280" ]]; then 
     echo "Incorrect output: Number of reads mapped"
+    echo "  Expected: 26280, Got: $READS"
     exit 1
 fi
 # 2. Genome Completeness
-if [[ `awk -F, '$1 == "Sample1" {print $6}' ./results/overall_sample_quality.csv` != 0.845519 ]]; then 
+COMPLETENESS=`awk -F, '$1 == "Sample1" {print $6}' ./results/overall_sample_quality.csv | xargs printf "%.2f"`
+if [[ "$COMPLETENESS" != "0.85" ]]; then 
     echo "Incorrect output: Genome Completeness"
+    echo "  Expected: 0.85, Got: $COMPLETENESS"
     exit 1
 fi
 # 3. Check metadata put in correctly
-if [[ `awk -F, '$1 == "Sample1" {print $7}' ./results/overall_sample_quality.csv` != 231 ]]; then 
+CELL=`awk -F, '$1 == "Sample1" {print $7}' ./results/overall_sample_quality.csv`
+if [[ "$CELL" != "231" ]]; then 
     echo "Incorrect output: Metadata not parsed correctly"
+    echo "  Expected: 231, Got: $CELL"
     exit 1
 fi
 

--- a/.github/scripts/run_mpx_pipeline_metadata.sh
+++ b/.github/scripts/run_mpx_pipeline_metadata.sh
@@ -8,7 +8,7 @@ nextflow run ./main.nf \
     -profile conda,test \
     --cache ./conda_cache_dir \
     --directory $PWD/.github/ci-data/ \
-    --human_ref $PWD/.github/ci-data/partial_hg38_ref.fa
+    --human_ref $PWD/.github/ci-data/partial_hg38_ref.fa \
     --metadata_csv $PWD/.github/ci-data/test_metadata.csv
 
 # Check that the output is as expected

--- a/.github/scripts/run_mpx_pipeline_metadata.sh
+++ b/.github/scripts/run_mpx_pipeline_metadata.sh
@@ -13,17 +13,17 @@ nextflow run ./main.nf \
 
 # Check that the output is as expected
 # 1. Num Reads
-if [[ `awk -F, '$1 == "Sample1" {print $2}' overall_sample_quality.csv` != 26280 ]]; then 
+if [[ `awk -F, '$1 == "Sample1" {print $2}' ./results/overall_sample_quality.csv` != 26280 ]]; then 
     echo "Incorrect output: Number of reads mapped"
     exit 1
 fi
 # 2. Genome Completeness
-if [[ `awk -F, '$1 == "Sample1" {print $6}' overall_sample_quality.csv` != 0.845519 ]]; then 
+if [[ `awk -F, '$1 == "Sample1" {print $6}' ./results/overall_sample_quality.csv` != 0.845519 ]]; then 
     echo "Incorrect output: Genome Completeness"
     exit 1
 fi
 # 3. Check metadata put in correctly
-if [[ `awk -F, '$1 == "Sample1" {print $7}' overall_sample_quality.csv` != 231 ]]; then 
+if [[ `awk -F, '$1 == "Sample1" {print $7}' ./results/overall_sample_quality.csv` != 231 ]]; then 
     echo "Incorrect output: Metadata not parsed correctly"
     exit 1
 fi

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    # Setup repo
     - uses: actions/checkout@v3
     - name: Create artifacts dir
       run: mkdir -p artifacts
@@ -24,6 +25,8 @@ jobs:
       uses: actions/setup-python@v3
       with: 
         python-version: 3.9
+    
+    # Add conda, mamba, and nextflow
     - name: Add Conda to system
       run: |
         # $CONDA is an environment variable pointing to the root of the miniconda directory
@@ -36,10 +39,23 @@ jobs:
     - name: Nextflow Version
       run: | 
         nextflow -v
+
+    # Check how repo looks incase there is an issue
     - name: List Files
       run: |
         ls -al ${{ github.workspace }}
-    - name: Run Nextflow Monkeypox-NF Pipeline
+
+    # Run Help Command
+    - name: Pipeline Help CMD
+      run: |
+        nextflow run ./main.nf --help
+    
+    # Run Pipelines
+    - name: Run Metagenomic Illumina Pipeline
       run: bash .github/scripts/run_mpx_pipeline.sh
-    - name: Done
-      run: echo "Done"
+
+    - name: Run Metagenomic Illumina Pipeline with Metadata
+      run: bash .github/scripts/run_mpx_pipeline_metadata.sh
+
+    - name: Done Pipelines
+      run: echo "Done running pipelines"

--- a/README.md
+++ b/README.md
@@ -116,18 +116,56 @@ nextflow run phac-nml/monkeypox-nf --help
 ```
 
 ### Inputs
+
+#### Parameters
+
 | Parameter | Description | Default | Optional |
 |-|-|-|-|
-| directory | Path to directory containing paired fastq reads | None | No |
-| human_ref | Path to fasta formatted human reference genome | None | No |
-| outdir | String name to call output results directory | 'results' | Yes |
-| mpx_ref | Path to fasta formatted monkeypox reference genome | 'data/NC_063383.fasta' | Yes |
-| mpx_ref_id | String name of reference monkeypox contig ID to keep during host removal | 'NC_063383.1' | Yes |
-| pcr_csv | Path to CSV file containing qPCR diagnostic primers for nextclade input (must follow nextclade's format) | 'data/nml_primers.csv' | Yes |
-| cache | Path to cache directory to store/reuse conda environments | None | Yes |
-| composite_bwa_index_dir | Path to directory containing BWA indexed composite genome to skip indexing step | None | Yes |
-| kraken_db | Path to directory containing Kraken2 database - Runs Kraken2 on the generated dehosted fastq files | None | Yes |
-| kraken_viral_id | String Kraken2 taxonomic identifier to use for the percent viral reads calculation. Default is the Integer ID for the Viruses domain | 10239 | Yes |
+| --directory | Path to directory containing paired fastq reads | None | No |
+| --human_ref | Path to fasta formatted human reference genome | None | No |
+| --outdir | String name to call output results directory | 'results' | Yes |
+| --mpx_ref | Path to fasta formatted monkeypox reference genome | 'data/NC_063383.fasta' | Yes |
+| --mpx_ref_id | String name of reference monkeypox contig ID to keep during host removal | 'NC_063383.1' | Yes |
+| --pcr_csv | Path to CSV file containing qPCR diagnostic primers for nextclade input (must follow nextclade's format) | 'data/nml_primers.csv' | Yes |
+| --cache | Path to cache directory to store/reuse conda environments | None | Yes |
+| --composite_bwa_index_dir | Path to directory containing BWA indexed composite genome to skip indexing step | None | Yes |
+| --metadata_csv | Path to metadata CSV with atleast a column called 'sample' to add in additional metadata (like 'date') | None | Yes |
+| --kraken_db | Path to directory containing Kraken2 database - Runs Kraken2 on the generated dehosted fastq files | None | Yes |
+| --kraken_viral_id | String Kraken2 taxonomic identifier to use for the percent viral reads calculation. Default is the Integer ID for the Viruses domain | 10239 | Yes |
+| --upload_config | Path to IRIDA uploader config file (example below). Also requires a metadata CSV file input with columns 'sample', 'project_id', and 'sequencing_date' | None | Yes |
+
+#### Example Metadata CSV
+
+1. General CSV - Must have "sample" column
+
+    | sample | Collection Location | Collection Date | ct value |
+    |-|-|-|-|
+    | sample_1 | swab | 2022-06-10 | 23.12 |
+    | sample_2 | lesion | 2022-07-11 | 26.12 |
+    | pos_ctrl | NA | NA | 18.3 |
+    | test_specimen | NA | NA | 22.51 |
+
+2. Upload CSV - Must have "sample", "project_id", and "sequencing_date" columns
+
+    | sample | Collection Location | Collection Date | ct value | project_id | sequencing_date |
+    |-|-|-|-|-|-|
+    | sample_1 | swab | 2022-06-10 | 23.12 | 1041 | 2022-08-01 |
+    | sample_2 | lesion | 2022-07-11 | 26.12 | 1042 | 2022-08-01 |
+    | pos_ctrl | NA | NA | 18.3 | 23 | 2022-08-01 |
+    | test_specimen | NA | NA | 22.51 | 515 | 2022-07-29 |
+
+
+#### Example IRIDA Upload Config
+
+```conf
+[Settings]
+client_id = upload
+client_secret = TsdafnJFDS3%4fds@fiLKjwK9932hiuHF
+username = process_uploader
+password = WeDfIejaC19*Y..1P013
+base_url = http://an-irida-upload-url.ca/irida/api/
+parser = directory
+```
 
 ### Outputs
 

--- a/bin/irida_upload_csv_generator.py
+++ b/bin/irida_upload_csv_generator.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+import pathlib
+import re
+import subprocess
+import pandas as pd
+
+from collections import defaultdict
+
+def init_parser() -> argparse.ArgumentParser:
+    '''
+    Purpose
+    -------
+    Parse CL inputs to be used in script
+    '''
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--directory',
+        '-d',
+        required=False,
+        default=False,
+        help='Path to directory containing dehosted paired fastq files or consensus sequences to rename and add an upload SampleList.csv file to'
+    )
+    parser.add_argument(
+        '--samplesheet',
+        '-s',
+        required=True,
+        help='File path to comma separated samplesheet with the following columns: ["sample", "project_id", "sequencing_date"]'
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument('--fastq', action='store_true', help="Create SampleList for paired illumina fastq files")
+    group.add_argument('--fasta', action='store_true', help="Create SampleList for consensus fasta files")
+    return parser
+
+def _add_to_paired_dict(dict: dict, full_path: str, name: str, read: str) -> None:
+    '''
+    Purpose
+    -------
+        Helper function to add found values to read dict
+
+    Parameters
+    ----------
+        dict: dict
+            Dictionary format paired read values to
+        full_path: str
+            Path to input file
+        name: str
+            Name of input file
+        read: str
+            Read number. Either _R1 or _R2
+    '''
+    # Add to key
+    if name in dict:
+        if (read == '_R1') or (read == '.pair1'):
+            dict[name]['forward'] = full_path
+        elif (read == '_R2') or (read == '.pair2'):
+            dict[name]['reverse'] = full_path
+        else:
+            return
+    # If not in dict, create key
+    else:
+        if (read == '_R1') or (read == '.pair1'):
+            dict[name]['forward'] = full_path
+        elif (read == '_R2') or (read == '.pair2'):
+            dict[name]['reverse'] = full_path
+        else:
+            return
+
+def create_sample_file_df(samplesheet: str, directory: str, file_type='') -> pd.DataFrame:
+    '''
+    Purpose
+    -------
+        Take input samplesheet, directory, and file type to create a df of values needed for IRIDA Uploads along
+        with renaming the files to include the sequencing date for better tracking
+
+    Parameters
+    ----------
+        samplesheet: path
+            CSV samplesheet containing the columns ["sample", "project_id", "sequencing_date"]
+        directory: path
+            Path to directory containing the files wanting to upload
+        file_type: str
+            Eithe fasta or fastq for what type of files we want to upload
+
+    Returns
+    -------
+        df_out: pd.DataFrame
+            Dataframe with files formatted to be used by IRIDA Uploader
+    '''
+    # Read in input TSV file
+    df = pd.read_csv(samplesheet, sep=',')
+
+    # Setup Dict of files -  Ex. {'sampleName': {'forward': '/Path/to/sampleName_R1.fastq', 'reverse': '/Path/to/sampleName_R2.fastq'}}
+    file_dict = defaultdict(lambda: defaultdict(str))
+    
+    # Set file regex based on data type. Regex statements are based on pipeline output names so if those change we must adjust here
+    if file_type == 'fastq':
+        FILE_WANTED_REGEX = re.compile(r'([^/]*)_dehosted.*(_R[12])\.fastq$')
+    else:
+        FILE_WANTED_REGEX = re.compile(r'(^.+)\.consensus\.(fa|fasta)$')
+
+    # Populate dict with files
+    for file_found in os.listdir(directory):
+        match = re.search(FILE_WANTED_REGEX, file_found)
+        if match and file_type =='fastq':
+            _add_to_paired_dict(file_dict, file_found, match.group(1), match.group(2))
+        elif match and file_type =='fasta':
+            file_dict[match.group(1)]['forward'] = file_found
+            file_dict[match.group(1)]['reverse'] = ''
+        else:
+            print('WARNING: No matches for file {}'.format(file_found))
+
+    # Generate Out DF from values in input table that have matching files found
+    row_list = []
+    for sample, proj_id, seq_date in zip(df['sample'], df['project_id'], df['sequencing_date']):
+        # Check if sample string a is a substring of any files and then add it to df_out if so
+        if sample in file_dict.keys():
+            ext = ''.join(pathlib.Path(file_dict[sample]['forward']).suffixes)
+
+            # Rename for better tracking
+            if file_type == 'fastq':
+                full_path_f = pathlib.Path(directory, file_dict[sample]['forward'])
+                new_file_name_f = '{}_{}_R1{}'.format(sample, seq_date, ext)
+                new_path_f = pathlib.Path(directory, new_file_name_f)
+                
+                full_path_r = pathlib.Path(directory, file_dict[sample]['reverse'])
+                new_file_name_r = '{}_{}_R2{}'.format(sample, seq_date, ext)
+                new_path_r = pathlib.Path(directory, new_file_name_r)
+
+                subprocess.run(['mv', full_path_f, new_path_f])
+                subprocess.run(['mv', full_path_r, new_path_r])
+            else:
+                full_path_f = pathlib.Path(directory, file_dict[sample]['forward'])
+                new_file_name_f = '{}_{}{}'.format(sample, seq_date, ext)
+                new_path_f = pathlib.Path(directory, new_file_name_f)
+
+                new_file_name_r = ''
+
+                subprocess.run(['mv', full_path_f, new_path_f])
+            row_dict = {
+                    'Sample_Name': sample,
+                    'Project_ID': proj_id, 
+                    'File_Forward': new_file_name_f, 
+                    'File_Reverse': new_file_name_r
+                }
+            row_list.append(row_dict)
+    df_out = pd.DataFrame(row_list, columns=['Sample_Name', 'Project_ID', 'File_Forward', 'File_Reverse'])
+    return df_out
+
+def main() -> None:
+    """
+    Purpose
+    -------
+        Main process. Checks and uploads metadata to IRIDA
+    """
+    # Init Parser and set arguments
+    parser = init_parser()
+    args = parser.parse_args()
+
+    # Create df_out using directory files and the sample TSV file based on the input file type wanted
+    if args.fastq:
+        df_out = create_sample_file_df(args.samplesheet, args.directory, file_type='fastq')
+    else:
+        df_out = create_sample_file_df(args.samplesheet, args.directory, file_type='fasta')
+
+    # Output
+    with open('{}/SampleList.csv'.format(args.directory), 'w') as handle:
+        handle.write('[Data]\n')
+    
+    df_out.to_csv('{}/SampleList.csv'.format(args.directory), mode='a', header=True, index=False)
+
+if __name__ == "__main__":
+    main()

--- a/bin/upload.py
+++ b/bin/upload.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+
+import argparse
+import configparser
+import pandas as pd
+
+from iridauploader import api, model
+
+def init_parser() -> argparse.ArgumentParser:
+    '''
+    Purpose
+    -------
+    Parse CL Parameters to be used in script
+    '''
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-c',
+        '--config',
+        required=True,
+        help='Irida Uploader config file to parse'
+    )
+    parser.add_argument(
+        '-m',
+        '--metadata_csv',
+        required=True,
+        help='Metadata qc csv for upload containing matching ids to SampleList.csv in the FIRST column and a project id in the SECOND'
+    )
+    parser.add_argument(
+        '--no_sample_creation',
+        required=False,
+        default=False,
+        action='store_true',
+        help='Turns off sample creation for sample names not found in IRIDA'
+    )
+    return parser
+
+def generate_api_instance(config_f) -> api.ApiCalls:
+    '''
+    Purpose
+    -------
+        Generate api instance for IRIDA platform based on input keys found in csv file
+
+    Parameters
+    ----------
+        config: path
+            IRIDA Uploader config file to be used to connect to IRIDA
+
+    Returns
+    -------
+        irida_api: ApiCalls object
+            Connection to IRIDA API based on keys given in config
+    '''
+    config = configparser.ConfigParser()
+    config.read(config_f)
+    settings = config['Settings']
+    irida_api = api.ApiCalls(settings['client_id'], settings['client_secret'], settings['base_url'], settings['username'], settings['password'])
+    return irida_api
+
+def _create_sample_status_dict(sample: str, project_id: int, uploaded: bool, status: str) -> dict:
+    """
+    Purpose
+    -------
+        Create and return individual dictionaries for tracking status of uploaded metadata samples
+
+    Parameters
+    ----------
+        sample: str
+            Sample name
+        project_id: int
+            IRIDA project sample was sent to
+        uploaded: bool
+            Was data uploaded
+        status: str
+            Info on upload bool
+
+    Returns
+    -------
+        d: dict
+            Dictionary containing above combined information
+    """
+    d = {
+        'sample': sample,
+        'project_id': project_id,
+        'uploaded': uploaded,
+        'status': status
+    }
+    return d
+
+def send_metadata(api_instance: api.ApiCalls, metadata_csv: str, no_sample_creation: bool) -> list:
+    '''
+    Purpose
+    -------
+        Send metadata for each sample in the input CSV file given a valid project ID
+
+    Parameters
+    ----------
+        irida_api: ApiCalls object
+            Connection to IRIDA API based on keys given in config
+        metadata_csv: path
+            CSV file that contains all of the metadata along with the sample name and project id
+        no_sample_creation: bool
+            If true, samples not already in IRIDA are skipped instead of created
+
+    Returns
+    -------
+        tracking_dict_list: list(dicts)
+            List of dictionarys containing the status of each samples upload
+    '''
+    df_in_dict = pd.read_csv(metadata_csv).fillna('NA').to_dict(orient='records')
+    tracking_dict_list = [] # List to append dicts that track the status of samples for data uploads
+
+    # Process and Upload each entry in input csv
+    for metadata_dict in df_in_dict:
+        sample_name = str(metadata_dict.pop('sample'))
+        project_id = metadata_dict.pop('project_id')
+
+        # Check if we have a project ID that is an integer for IRIDA
+        try:
+            project_id_int = int(project_id)
+        except ValueError:
+            print('Unknown Project ID for sample {}, moving to next sample'.format(project_id, sample_name))
+            tracking_dict_list.append(_create_sample_status_dict(sample_name, project_id, False, 'Unknown Project ID'.format()))
+            continue
+
+        # Check that sample exists and if the new values are better than previous
+        sample_id = api_instance.get_sample_id(sample_name=sample_name, project_id=project_id_int)
+        if sample_id:
+            # We have a sample in IRIDA already. Can add whatever checks we want to restrict uploads here
+            pass
+        # If given, skip samples that are not in IRIDA already
+        elif no_sample_creation:
+            print('Skipped sample {} metadata as it is not in IRIDA and --no_sample_creation arg passed'.format(sample_name))
+            tracking_dict_list.append(_create_sample_status_dict(sample_name, project_id_int, False, 'Not in IRIDA and --no_sample_creation arg passed'))
+            continue
+        # If sample does not already exist, create it and grab its sample_id
+        else:
+            irida_sample = model.Sample(sample_name=sample_name)
+            response = api_instance.send_sample(sample=irida_sample, project_id=project_id_int)
+            sample_id = response['resource']['identifier']
+
+        # Push data to IRIDA
+        upload_metadata = model.Metadata(metadata=metadata_dict, project_id=project_id_int, sample_name=sample_name)
+        status = api_instance.send_metadata(upload_metadata, sample_id)
+        print('Uploaded {} metadata to {}'.format(sample_name, project_id_int))
+        tracking_dict_list.append(_create_sample_status_dict(sample_name, project_id_int, True, ''))
+
+    return tracking_dict_list
+
+def main() -> None:
+    """
+    Purpose
+    -------
+        Main process. Checks and uploads metadata to IRIDA
+    """
+    # Init Parser and set arguments
+    parser = init_parser()
+    args = parser.parse_args()
+
+    # Connect and upload metadata
+    irida_api = generate_api_instance(args.config)
+    tracking_dict_list = send_metadata(irida_api, args.metadata_csv, args.no_sample_creation)
+
+    # Output tracking df
+    df = pd.DataFrame.from_dict(tracking_dict_list)
+    df.to_csv('metadata_upload_status.csv', index=False)
+
+if __name__ == "__main__":
+    main()

--- a/conf/conda.config
+++ b/conf/conda.config
@@ -3,4 +3,10 @@ process {
     withName: 'runKraken2' {
         conda = "$baseDir/environments/kraken2.yml"
     }
+    withName: 'uploadMetadata' {
+        conda = "$baseDir/environments/irida.yml"
+    }
+    withName: 'uploadSequenceData' {
+        conda = "$baseDir/environments/irida.yml"
+    }
 }

--- a/conf/custom/nml.config
+++ b/conf/custom/nml.config
@@ -10,6 +10,10 @@ env {
 
 // Default and Process Specific Computing Needs //
 process {
+    // Allow up to 3 retries per process
+    errorStrategy   = 'retry'
+    maxRetries      = 3
+
     // Default Paramaters for NML Slurm Cluster //
     executor    = "slurm"
     queue       = "${params.partition}"
@@ -24,6 +28,12 @@ process {
     withLabel: largeProcess {
         cpus    = 8
         memory  = 64.GB
+    }
+
+    withLabel: upload {
+        cpus            = 2
+        memory          = 16.GB
+        errorStrategy   = 'terminate'
     }
 
     // Specific Process Needs //

--- a/conf/resources.config
+++ b/conf/resources.config
@@ -17,6 +17,10 @@ process {
         cpus        = 4
         memory      = 16.GB
     }
+    withLabel: upload {
+        cpus    = 2
+        memory  = 8.GB
+    }
 
     // Specific Process Needs //
     withName: grabCompositeIndex {

--- a/environments/irida.yml
+++ b/environments/irida.yml
@@ -1,0 +1,7 @@
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - irida-uploader
+  - pandas

--- a/lib/NextflowInitialize.groovy
+++ b/lib/NextflowInitialize.groovy
@@ -26,18 +26,24 @@ class NextflowInitialize {
                 --cache [path]                      (With conda profile only) Path to cache directory containing conda environments
                 --composite_bwa_index_dir [path]    Path to directory containing BWA indexed composite genome to skip indexing step
                                                       Make sure it matches the Human and MPXV reference sequences or pipeline will not work
+                --metadata_csv [file]               Add metadata to output CSV. Requires column called 'sample'
+                                                      If uploading to IRIDA also needs columns 'project_id' and 'sequencing_date'
 
             Optional Preset Arguments:
                 --outdir [str]                  String name for the output results directory (Default: 'results')
                 --mpx_ref [path]                Path to monkeypox reference genome (Default: 'data/NC_063383.fasta')
                 --mpx_ref_id [str]              String name of reference monkeypox contig ID to keep during host removal (Default: 'NC_063383.1')
-                --pcr_csv [path]                Path to CSV file containing qPCR primers for nextclade to intake (Default: 'data/nml_primers.csv')
+                --pcr_csv [file]                Path to CSV file containing qPCR primers for nextclade to intake (Default: 'data/nml_primers.csv')
 
             Optional Run Kraken2 Arguments:
                 --kraken_db [path]              Path to directory containing Kraken2 database
                                                   Runs Kraken2 on the generated dehosted fastq files when used
                 --kraken_viral_id [str]         String Kraken2 taxonomic identifier to use for the percent viral reads calculation. 
                                                   Default is the Integer ID for the Viruses domain - 10239
+
+            Optional Upload to IRIDA Arguments:
+                --upload_config [file]          Path to IRIDA uploader config file (example in README)
+                                                  Also need to provide a metadata csv file with columns 'sample', 'project_id' and 'sequencing_date'
             """.stripIndent()
             System.exit(0)
         }
@@ -51,6 +57,30 @@ class NextflowInitialize {
         if ( !params.human_ref ) {
             log.error "Please specify a human reference genome with '--human_ref <REF>'"
             System.exit(1)
+        }
+
+        if ( params.upload_config && !params.metadata_csv ) {
+            log.error "IRIDA Upload requested but no metadata CSV file given. To upload, re-run with a valid metadata file adding on --metadata_csv <FILE.csv>"
+            System.exit(1)
+        }
+
+        // Check CSV Metadata Headers for correct values based on if upload is wanted or not
+        if ( params.metadata_csv ) {
+            def firstLine = new File(params.metadata_csv).readLines().get(0)
+            def entries = firstLine.split(',')
+            if ( params.upload_config ) {
+                if ( !entries.contains('sample') | !entries.contains('project_id') | !entries.contains('sequencing_date') ) {
+                    log.error """
+                    IRIDA Upload requested but input metadata CSV file does not contain the needed headers
+                      Requires at minimum: ['sample', 'project_id', 'sequencing_date']
+                      Got: $entries
+                    """.stripIndent()
+                }
+            } else {
+                if ( !entries.contains('sample') ) {
+                    log.error "Input metadata CSV file does not contain the 'sample' header"
+                }
+            }
         }
 
         // Print Starting Niceness

--- a/modules/main_modules.nf
+++ b/modules/main_modules.nf
@@ -1,5 +1,5 @@
 process generateSamplesheet {
-    publishDir "${params.outdir}/", pattern: "samplesheet.csv", mode: "copy"
+    publishDir "${params.tracedir}/", pattern: "samplesheet.csv", mode: "copy"
     tag { directory }
 
     input:

--- a/modules/quality_modules.nf
+++ b/modules/quality_modules.nf
@@ -66,6 +66,7 @@ process concatQuality {
     input:
     path(csvs)
     path(nextclade_csv)
+    path(metadata_csv)
 
     output:
     path ("overall_sample_quality.csv")
@@ -73,6 +74,7 @@ process concatQuality {
     script:
     """
     awk '(NR == 1) || (FNR > 1)' *quality.csv > simple_sample_quality.csv
-    csvtk join -f 'sample;seqName' simple_sample_quality.csv $nextclade_csv > overall_sample_quality.csv
+    sed -i '1s/seqName/sample/' $nextclade_csv
+    csvtk join --left-join --na 'NA' -f 'sample' simple_sample_quality.csv $metadata_csv $nextclade_csv > overall_sample_quality.csv
     """
 }

--- a/modules/upload_modules.nf
+++ b/modules/upload_modules.nf
@@ -1,28 +1,47 @@
-process uploadMetadata {
-
-    tag { sample }
-
-    label 'upload'
-
-    input:
-
-    output:
-
-    script:
-    """
-    """
-}
 process uploadSequenceData {
 
-    tag { sample }
+    label 'upload'
+
+    input:
+    path(fastas)
+    path(read1s)
+    path(read2s)
+    path(config)
+    path(metadata)
+
+    output:
+    path("done_sequence_upload.txt")
+
+    script:
+    """
+    mkdir -p irida_fastqs
+    mv $read1s irida_fastqs
+    mv $read2s irida_fastqs
+    irida_upload_csv_generator.py --directory irida_fastqs/ --samplesheet $metadata --fastq
+    irida-uploader --config $config -d irida_fastqs
+
+    mkdir -p irida_fastas
+    mv $fastas irida_fastas
+    irida_upload_csv_generator.py --directory irida_fastas/ --samplesheet $metadata --fasta
+    irida-uploader --config $config -d irida_fastas --upload_mode=assemblies
+    touch done_sequence_upload.txt
+    """
+}
+process uploadMetadata {
+    publishDir "${params.outdir}/", pattern: "metadata_upload_status.csv", mode: "copy"
 
     label 'upload'
 
     input:
+    path(metadata_csv)
+    path(config)
+    path(prev_upload_file)
 
     output:
+    path("metadata_upload_status.csv")
 
     script:
     """
+    upload.py --config $config --metadata_csv $metadata_csv
     """
 }

--- a/modules/upload_modules.nf
+++ b/modules/upload_modules.nf
@@ -10,21 +10,36 @@ process uploadSequenceData {
     path(metadata)
 
     output:
-    path("done_sequence_upload.txt")
+    path("done_sequence_uploads.txt")
 
     script:
     """
+    ### Fastq files ###
     mkdir -p irida_fastqs
     mv $read1s irida_fastqs
     mv $read2s irida_fastqs
-    irida_upload_csv_generator.py --directory irida_fastqs/ --samplesheet $metadata --fastq
-    irida-uploader --config $config -d irida_fastqs
+    irida_upload_csv_generator.py \
+        --directory irida_fastqs/ \
+        --samplesheet $metadata \
+        --fastq
+    irida-uploader \
+        --config $config \
+        -d irida_fastqs
 
+    ### Fasta files ###
     mkdir -p irida_fastas
     mv $fastas irida_fastas
-    irida_upload_csv_generator.py --directory irida_fastas/ --samplesheet $metadata --fasta
-    irida-uploader --config $config -d irida_fastas --upload_mode=assemblies
-    touch done_sequence_upload.txt
+    irida_upload_csv_generator.py \
+        --directory irida_fastas/ \
+        --samplesheet $metadata \
+        --fasta
+    irida-uploader \
+        --config $config \
+        -d irida_fastas \
+        --upload_mode=assemblies
+
+    ### Control upload flow ###
+    touch done_sequence_uploads.txt
     """
 }
 process uploadMetadata {

--- a/modules/upload_modules.nf
+++ b/modules/upload_modules.nf
@@ -1,0 +1,28 @@
+process uploadMetadata {
+
+    tag { sample }
+
+    label 'upload'
+
+    input:
+
+    output:
+
+    script:
+    """
+    """
+}
+process uploadSequenceData {
+
+    tag { sample }
+
+    label 'upload'
+
+    input:
+
+    output:
+
+    script:
+    """
+    """
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -13,7 +13,7 @@ params {
 
     // Optional Inputs
     composite_bwa_index_dir = null      // Will speed up subsequent runs!
-    metadata_tsv            = null      // Add metadata to output CSV. Requires column called 'sample'
+    metadata_csv            = null      // Add metadata to output CSV. Requires column called 'sample'
 
     // Optional Run Kraken2 
     kraken_db               = null      // Path to database directory, will run when given
@@ -22,7 +22,6 @@ params {
     // Optional IRIDA Upload
     upload_config           = null      // IRIDA Upload config file
     project_id              = null      // Project to send all samples to. If there is a project_id column in metadata can keep this null
-    
 
     // General Nextflow
     outdir                  = './results'

--- a/nextflow.config
+++ b/nextflow.config
@@ -14,6 +14,7 @@ params {
     // Optional Inputs
     composite_bwa_index_dir = null      // Will speed up subsequent runs!
     metadata_csv            = null      // Add metadata to output CSV. Requires column called 'sample'
+                                        //    If uploading to IRIDA also needs columns 'project_id' and 'sequencing_date'
 
     // Optional Run Kraken2 
     kraken_db               = null      // Path to database directory, will run when given
@@ -21,12 +22,12 @@ params {
 
     // Optional IRIDA Upload
     upload_config           = null      // IRIDA Upload config file
-    project_id              = null      // Project to send all samples to. If there is a project_id column in metadata can keep this null
+                                        //    Need to provide a metadata csv with columns 'sample', 'project_id' and 'sequencing_date'
 
     // General Nextflow
-    outdir                  = './results'
-    help                    = null
+    outdir                  = "./results"
     tracedir                = "${params.outdir}/pipeline_info"
+    help                    = null
 
     // Conda Specific
     cache                   = null
@@ -69,21 +70,22 @@ profiles {
 // Capture exit codes from upstream processes when piping
 process.shell = ['/bin/bash', '-euo', 'pipefail']
 
+def timestamp = new java.util.Date().format( 'yyyy-MM-dd_HH-mm-ss')
 timeline {
-    enabled = false
-    file    = "${params.tracedir}/execution_timeline.html"
+    enabled = true
+    file    = "${params.tracedir}/execution_timeline_${timestamp}.html"
 }
 report {
-    enabled = false
-    file    = "${params.tracedir}/execution_report.html"
+    enabled = true
+    file    = "${params.tracedir}/execution_report_${timestamp}.html"
 }
 trace {
-    enabled = false
-    file    = "${params.tracedir}/execution_trace.txt"
+    enabled = true
+    file    = "${params.tracedir}/execution_trace_${timestamp}.txt"
 }
 dag {
     enabled = false
-    file    = "${params.tracedir}/pipeline_dag.svg"
+    file    = "${params.tracedir}/pipeline_dag_${timestamp}.html"
 }
 
 manifest {

--- a/nextflow.config
+++ b/nextflow.config
@@ -11,12 +11,18 @@ params {
     mpx_ref_id              = 'NC_063383.1'
     pcr_csv                 = "$baseDir/data/nml_primers.csv"
 
-    // Optional Input to speed up subsequent runs
-    composite_bwa_index_dir = null
+    // Optional Inputs
+    composite_bwa_index_dir = null      // Will speed up subsequent runs!
+    metadata_tsv            = null      // Add metadata to output CSV. Requires column called 'sample'
 
-    // Optional Run Kraken2 - DB is the path to the database directory, viral_id is the kraken2 ID for Viruses Domain
-    kraken_db               = null
-    kraken_viral_id         = 10239
+    // Optional Run Kraken2 
+    kraken_db               = null      // Path to database directory, will run when given
+    kraken_viral_id         = 10239     // kraken2 ID for Viruses Domain, can change it to whatever kraken taxonomic ID
+
+    // Optional IRIDA Upload
+    upload_config           = null      // IRIDA Upload config file
+    project_id              = null      // Project to send all samples to. If there is a project_id column in metadata can keep this null
+    
 
     // General Nextflow
     outdir                  = './results'

--- a/workflows/mpx_main.nf
+++ b/workflows/mpx_main.nf
@@ -51,8 +51,7 @@ workflow mpx_main {
 
         // Mapping and Filtering based on wanted ID
         compositeMapping(
-            ch_paired_fastqs
-                .combine( ch_comp_ref ),
+            ch_paired_fastqs.combine( ch_comp_ref ),
             ch_comp_idx
         )
 
@@ -68,19 +67,23 @@ workflow mpx_main {
         ivarConsensus( filterBam0.out.filteredbam )
 
         // Quality Workflow //
+        if ( params.metadata_csv ) { ch_metadata = file( params.metadata_csv ) } else { ch_metadata = [] }
+
         assess_quality( 
             ivarConsensus.out,
             filterBam0.out.filteredbam,
             compositeMapping.out.sortedbam,
-            host_removal.out.kraken_results
+            host_removal.out.kraken_results,
+            ch_metadata
         )
 
         // Upload Workflow //
         if ( params.upload_config ) {
             upload(
-                ivarConsensus.out
-                host_removal.out.dehosted_fastq
-                assess_quality.out.sequence_metrics
+                ivarConsensus.out,
+                host_removal.out.dehosted_fastq,
+                assess_quality.out.sequence_metrics,
+                ch_metadata
             )
         }
 }

--- a/workflows/mpx_main.nf
+++ b/workflows/mpx_main.nf
@@ -11,9 +11,10 @@ include {
     } from '../modules/main_modules.nf'
 
 // Workflows to Include
-include { initial_analysis } from './workflow_initial_analysis.nf'
-include { host_removal }   from './workflow_removal.nf'
-include { assess_quality } from './workflow_quality.nf'
+include { initial_analysis }    from './subworkflows/initial_analysis.nf'
+include { host_removal }        from './subworkflows/host_removal.nf'
+include { assess_quality }      from './subworkflows/quality.nf'
+include { upload }              from './subworkflows/upload.nf'
 
 workflow mpx_main {
     main:
@@ -67,5 +68,19 @@ workflow mpx_main {
         ivarConsensus( filterBam0.out.filteredbam )
 
         // Quality Workflow //
-        assess_quality( ivarConsensus.out, filterBam0.out.filteredbam, compositeMapping.out.sortedbam, host_removal.out.kraken_results )
+        assess_quality( 
+            ivarConsensus.out,
+            filterBam0.out.filteredbam,
+            compositeMapping.out.sortedbam,
+            host_removal.out.kraken_results
+        )
+
+        // Upload Workflow //
+        if ( params.upload_config ) {
+            upload(
+                ivarConsensus.out
+                host_removal.out.dehosted_fastq
+                assess_quality.out.sequence_metrics
+            )
+        }
 }

--- a/workflows/mpx_main.nf
+++ b/workflows/mpx_main.nf
@@ -78,7 +78,7 @@ workflow mpx_main {
         )
 
         // Upload Workflow //
-        if ( params.upload_config ) {
+        if ( params.upload_config && params.metadata_csv ) {
             upload(
                 ivarConsensus.out,
                 host_removal.out.dehosted_fastq,

--- a/workflows/subworkflows/host_removal.nf
+++ b/workflows/subworkflows/host_removal.nf
@@ -2,7 +2,7 @@
 include {
     generateHostRemovedFastq;
     runKraken2
-} from '../modules/removal_modules.nf'
+} from '../../modules/removal_modules.nf'
 
 // Workflow to generate host removed reads and get read quality metrics
 workflow host_removal {
@@ -21,5 +21,6 @@ workflow host_removal {
             ch_kraken_results = ch_filtered_bam.map { it -> [ it[0], [] ] }
         }
     emit:
-    kraken_results = ch_kraken_results      // channel: [ val(sampleID), path(krakenReport) ]
+    kraken_results = ch_kraken_results              // channel: [ val(sampleID), path(krakenReport) ]
+    dehosted_fastq = generateHostRemovedFastq.out   // channel: [ val(sampleID), path(Read1), path(Read2), val(bool) ]
 }

--- a/workflows/subworkflows/initial_analysis.nf
+++ b/workflows/subworkflows/initial_analysis.nf
@@ -1,7 +1,7 @@
 // Modules to include
 include {
     runFastQC;
-} from '../modules/initial_analysis_modules.nf'
+} from '../../modules/initial_analysis_modules.nf'
 
 // Workflow for quality metrics and other checks
 workflow initial_analysis {

--- a/workflows/subworkflows/quality.nf
+++ b/workflows/subworkflows/quality.nf
@@ -29,7 +29,8 @@ workflow assess_quality {
         runNextclade( ch_fasta_only.files.collect() )
 
         // Singular CSV output
-        concatQuality( assessSimpleQuality.out.collect(), runNextclade.out )
+        if ( params.metadata_csv ) { ch_metadata = file( params.metadata_csv ) } else { ch_metadata = [] }
+        concatQuality( assessSimpleQuality.out.collect(), runNextclade.out, ch_metadata )
 
     emit:
     sequence_metrics = concatQuality.out        // channel: path(overall_sample_quality.csv)

--- a/workflows/subworkflows/quality.nf
+++ b/workflows/subworkflows/quality.nf
@@ -3,7 +3,7 @@ include {
     assessSimpleQuality;
     runNextclade;
     concatQuality
-} from '../modules/quality_modules.nf'
+} from '../../modules/quality_modules.nf'
 
 // Workflow for quality metrics and other checks
 workflow assess_quality {
@@ -31,5 +31,6 @@ workflow assess_quality {
         // Singular CSV output
         concatQuality( assessSimpleQuality.out.collect(), runNextclade.out )
 
-    //emit:
+    emit:
+    sequence_metrics = concatQuality.out        // channel: path(overall_sample_quality.csv)
 }

--- a/workflows/subworkflows/quality.nf
+++ b/workflows/subworkflows/quality.nf
@@ -12,6 +12,7 @@ workflow assess_quality {
         ch_filtered_bam             // channel: [ val(sampleID), path(filteredBam) ]
         ch_composite_bam            // channel: [ val(sampleID), path(compositeBam), path(compositeBamBai) ]
         ch_kraken_results           // channel: [ val(sampleID), path(krakenReport) ]
+        ch_metadata                 // channel: path(metadata_csv) or [] if none
 
     main:
         // Join fasta with bam and get some info
@@ -29,8 +30,11 @@ workflow assess_quality {
         runNextclade( ch_fasta_only.files.collect() )
 
         // Singular CSV output
-        if ( params.metadata_csv ) { ch_metadata = file( params.metadata_csv ) } else { ch_metadata = [] }
-        concatQuality( assessSimpleQuality.out.collect(), runNextclade.out, ch_metadata )
+        concatQuality(
+            assessSimpleQuality.out.collect(),
+            runNextclade.out,
+            ch_metadata
+        )
 
     emit:
     sequence_metrics = concatQuality.out        // channel: path(overall_sample_quality.csv)

--- a/workflows/subworkflows/upload.nf
+++ b/workflows/subworkflows/upload.nf
@@ -1,0 +1,20 @@
+// Modules to include
+include {
+    uploadMetadata;
+    uploadSequenceData
+} from '../../modules/upload_modules.nf'
+
+// Workflow for quality metrics and other checks
+workflow upload {
+    take:
+        ch_consensus_fasta          // channel: [ val(sampleID), path(fasta) ]
+        ch_dehosted_fastq           // channel: [ val(sampleID), path(Read1), path(Read2), val(bool) ]
+        ch_sequence_metrics         // channel: path(overall_sample_quality.csv)
+
+    main:
+        // Upload
+        uploadMetadata()
+        uploadSequenceData()
+
+    //emit:
+}

--- a/workflows/subworkflows/upload.nf
+++ b/workflows/subworkflows/upload.nf
@@ -10,11 +10,25 @@ workflow upload {
         ch_consensus_fasta          // channel: [ val(sampleID), path(fasta) ]
         ch_dehosted_fastq           // channel: [ val(sampleID), path(Read1), path(Read2), val(bool) ]
         ch_sequence_metrics         // channel: path(overall_sample_quality.csv)
+        ch_metadata                 // channel: path(metadata_csv) or [] if none
 
     main:
+        // Get config setup
+        ch_upload_conf = file( params.upload_config )
+
         // Upload
-        uploadMetadata()
-        uploadSequenceData()
+        uploadSequenceData(
+            ch_consensus_fasta.collect { it[1] },
+            ch_dehosted_fastq.collect { it[1] },
+            ch_dehosted_fastq.collect { it[2] },
+            ch_upload_conf,
+            ch_metadata
+        )
+        uploadMetadata(
+            ch_sequence_metrics,
+            ch_upload_conf,
+            uploadSequenceData.out // Added so that uploads are one at a time and samples don't conflict
+        )
 
     //emit:
 }


### PR DESCRIPTION
# Adding IRIDA Uploads to Pipeline
Automated IRIDA uploads save time and make it easier to track the final data

## Issues
Addresses #2 

## Changes
### Dev Changes
- New organization for subworkflows
    - All of the workflows used to be in one directory called `workflow_x`
    - Changed to all be in `subworkflows` dir called just the workflow name

## Other Checks
- [x] Manually checked that IRIDA uploads completed successfully on internal instance
    - [x] Metadata
    - [x] Fastq files
    - [x] Fasta files

## ToDo
- [x] Add IRIDA conda env
- [x] Add IRIDA Upload params
    - [x] Document in Readme
    - [x] Document in Help command
    - [x] Document in nextflow config
- [x] Add Upload Modules
- [x] Add Upload workflow
- [x] Update Tests to check output is as expected